### PR TITLE
Fix run-time exception on the object constructed with null

### DIFF
--- a/lib/optional_internal.dart
+++ b/lib/optional_internal.dart
@@ -24,7 +24,7 @@ abstract class Optional<T> {
 
   /// Creates a new Optional with the given value, if non-null.  Otherwise, returns an empty Optional.
   factory Optional.ofNullable(T value) =>
-      value == null ? const Optional.empty() : Optional.of(value);
+      value == null ? Optional<T>.empty() : Optional.of(value);
 
   /// Creates an empty Optional.
   const factory Optional.empty() = _Absent<T>._internal;

--- a/lib/optional_internal.dart
+++ b/lib/optional_internal.dart
@@ -5,7 +5,7 @@ part 'src/present.dart';
 part 'src/novaluepresent.dart';
 
 /// A constant, absent Optional.
-const Optional<dynamic> empty = _Absent<dynamic>();
+const Optional empty = Optional<dynamic>.empty();
 
 /// A container object which may contain a non-null value.
 ///
@@ -23,13 +23,8 @@ abstract class Optional<T> {
   }
 
   /// Creates a new Optional with the given value, if non-null.  Otherwise, returns an empty Optional.
-  factory Optional.ofNullable(T value) {
-    if (value == null) {
-      return empty.cast();
-    } else {
-      return _Present<T>(value);
-    }
-  }
+  factory Optional.ofNullable(T value) =>
+      value == null ? const Optional.empty() : Optional.of(value);
 
   /// Creates an empty Optional.
   const factory Optional.empty() = _Absent<T>._internal;

--- a/lib/src/absent.dart
+++ b/lib/src/absent.dart
@@ -12,13 +12,13 @@ class _Absent<T> implements Optional<T> {
   bool get isPresent => false;
 
   @override
-  Optional<T> filter(bool predicate(T val)) => empty.cast();
+  Optional<T> filter(bool predicate(T val)) => const Optional.empty();
 
   @override
-  Optional<R> flatMap<R>(Optional<R> mapper(T val)) => empty.cast();
+  Optional<R> flatMap<R>(Optional<R> mapper(T val)) => Optional<R>.empty();
 
   @override
-  Optional<R> map<R>(R mapper(T val)) => empty.cast();
+  Optional<R> map<R>(R mapper(T val)) => Optional<R>.empty();
 
   @override
   T orElse(T other) => other;

--- a/lib/src/present.dart
+++ b/lib/src/present.dart
@@ -16,7 +16,7 @@ class _Present<T> implements Optional<T> {
     if (predicate(_value))
       return this;
     else
-      return empty.cast();
+      return const Optional.empty();
   }
 
   @override

--- a/test/src/methods.dart
+++ b/test/src/methods.dart
@@ -81,19 +81,13 @@ void runMethodTests() {
           equals(const Optional<int>.empty()));
     });
     test('map when generic type changes', () {
-      var o = new Optional<int>.ofNullable(null).map((i) => 'i=$i');
-      expect(o, equals(const Optional<String>.empty()));
+      expect(Optional<int>.ofNullable(null).map((i) => 'i=$i'), equals(const Optional<String>.empty()));
     });
-
     test('map empty optional and then use orElse', () {
-      var o = const Optional<int>.empty().map((i) => 'i=$i').orElse('');
-      expect(o, equals(''));
+      expect(const Optional<int>.empty().map((i) => 'i=$i').orElse(''), equals(''));
     });
-
-
     test('map not empty optional and then use orElse', () {
-      var o = Optional<int>.of(5).map((i) => 'i=$i').orElse('');
-      expect(o, equals('i=5'));
+      expect( Optional<int>.of(5).map((i) => 'i=$i').orElse(''), equals('i=5'));
     });
   });
 

--- a/test/src/methods.dart
+++ b/test/src/methods.dart
@@ -112,6 +112,10 @@ void runMethodTests() {
     test('orElseThrow(f) returns value when present', () {
       expect(Optional.of(1).orElseThrow(() => 'exception'), equals(1));
     });
+    test('orElse of ofNullable', (){
+      expect(Optional<int>.ofNullable(null).orElse(0), equals(0));
+    });
+
   });
   group('ifPresent', () {
     final consumer = MockConsumer<int>();


### PR DESCRIPTION
This code results in runtime exception because Optional.ofNullable does not preserve the type information.

`Optional<int>.ofNullable(null).orElse(0), equals(0);`

This PR fix the issue.