### PR TITLE
Optional Iterable extension

### DIFF
--- a/example/optional_example.dart
+++ b/example/optional_example.dart
@@ -10,6 +10,7 @@ void main() {
   extensionExample();
   asyncExample();
   nullSafeNullableExample();
+  collectionsExample();
 }
 
 void emptyExample() {
@@ -130,4 +131,12 @@ void nullSafeNullableExample() {
   print(isNullable(i)); // prints "false"
   i = Optional.of(1).orElseGetNullable(() => 2);
   print(isNullable(i)); // prints "true"
+}
+
+void collectionsExample() {
+  final data = <int>[1,2,2,2,3];
+  print(data.firstOptional.isPresent); // prints "true"
+  print(data.firstWhereOptional((v) => v == 3).isPresent); // prints "true"
+  print(data.singleWhereOptional((v) => v == 3).isEmpty); // prints "true"
+  print(data.singleOptional.isPresent); // prints "false"
 }

--- a/lib/optional.dart
+++ b/lib/optional.dart
@@ -2,4 +2,4 @@
 library optional;
 
 export 'optional_internal.dart'
-    show Optional, OptionalExtension, NoValuePresentError, empty;
+    show Optional, OptionalExtension, OptionalIterableExtension, NoValuePresentError, empty;

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -4,3 +4,121 @@ extension OptionalExtension<T extends Object> on T {
   /// Returns an Optional with `this` as its value
   Optional<T> get toOptional => Optional.of(this);
 }
+
+/// Extensions that apply to all iterables.
+extension OptionalIterableExtension<T> on Iterable<T> {
+
+  /// The first element satisfying [test], or `Optional.empty()` if there are none.
+  Optional<T> firstWhereOptional(bool Function(T element) test) {
+    for (var element in this) {
+      if (test(element)) return Optional.of(element);
+    }
+    return Optional.empty();
+  }
+
+  /// The first element whose value and index satisfies [test].
+  ///
+  /// Returns `Optional.empty()` if there are no element and index satisfying [test].
+  Optional<T> firstWhereIndexedOptional(bool Function(int index, T element) test) {
+    var index = 0;
+    for (var element in this) {
+      if (test(index++, element)) return Optional.of(element);
+    }
+    return Optional.empty();
+  }
+
+  /// The first element, or `Optional.empty()` if the iterable is empty.
+  Optional<T> get firstOptional {
+    var iterator = this.iterator;
+    if (iterator.moveNext()) return Optional.of(iterator.current);
+    return Optional.empty();
+  }
+
+  /// The last element satisfying [test], or `Optional.empty()` if there are none.
+  Optional<T> lastWhereOptional(bool Function(T element) test) {
+    T? result;
+    for (var element in this) {
+      if (test(element)) result = element;
+    }
+    return Optional.ofNullable(result);
+  }
+
+  /// The last element whose index and value satisfies [test].
+  ///
+  /// Returns `Optional.empty()` if no element and index satisfies [test].
+  Optional<T> lastWhereIndexedOptional(bool Function(int index, T element) test) {
+    T? result;
+    var index = 0;
+    for (var element in this) {
+      if (test(index++, element)) result = element;
+    }
+    return Optional.ofNullable(result);
+  }
+
+  /// The last element, or `Optional.empty()` if the iterable is empty.
+  Optional<T> get lastOptional {
+    if (isEmpty) return Optional.empty();
+    return Optional.of(last);
+  }
+
+  /// The single element satisfying [test].
+  ///
+  /// Returns `Optional.empty()` if there are either no elements
+  /// or more than one element satisfying [test].
+  ///
+  /// **Notice**: This behavior differs from [Iterable.singleWhere]
+  /// which always throws if there are more than one match,
+  /// and only calls the `orElse` function on zero matchs.
+  Optional<T> singleWhereOptional(bool Function(T element) test) {
+    T? result;
+    var found = false;
+    for (var element in this) {
+      if (test(element)) {
+        if (!found) {
+          result = element;
+          found = true;
+        } else {
+          return Optional.empty();
+        }
+      }
+    }
+    return Optional.ofNullable(result);
+  }
+
+  /// The single element satisfying [test].
+  ///
+  /// Returns `Optional.empty()` if there are either none
+  /// or more than one element and index satisfying [test].
+  Optional<T> singleWhereIndexedOptional(bool Function(int index, T element) test) {
+    T? result;
+    var found = false;
+    var index = 0;
+    for (var element in this) {
+      if (test(index++, element)) {
+        if (!found) {
+          result = element;
+          found = true;
+        } else {
+          return Optional.empty();
+        }
+      }
+    }
+    return Optional.ofNullable(result);
+  }
+
+  /// The single element of the iterable, or `Optional.empty()`.
+  ///
+  /// The value is `Optional.empty()` if the iterable is empty
+  /// or it contains more than one element.
+  Optional<T> get singleOptional {
+    var iterator = this.iterator;
+    if (iterator.moveNext()) {
+      var result = iterator.current;
+      if (!iterator.moveNext()) {
+        return Optional.of(result);
+      }
+    }
+    return Optional.empty();
+  }
+
+}

--- a/test/src/extension.dart
+++ b/test/src/extension.dart
@@ -9,4 +9,82 @@ void runExtensionTests() {
       expect(1.toOptional, equals(Optional.of(1)));
     });
   });
+  group('iterable.firstWhereOptional', () {
+    test('iterable.firstWhereOptional is present', () {
+      expect(<int>[1,2,3].firstWhereOptional((v) => v == 3).isPresent, isTrue);
+    });
+    test('iterable.firstWhereOptional is empty', () {
+      expect(<int>[1,2,3].firstWhereOptional((v) => v == 4).isEmpty, isTrue);
+    });
+  });
+  group('iterable.firstWhereIndexedOptional', () {
+    test('iterable.firstWhereIndexedOptional is present', () {
+      expect(<int>[1,2,3].firstWhereIndexedOptional((i, v) => i == 2).isPresent, isTrue);
+    });
+    test('iterable.firstWhereIndexedOptional is empty', () {
+      expect(<int>[1,2,3].firstWhereIndexedOptional((i, v) => i == 4).isEmpty, isTrue);
+    });
+  });
+  group('iterable.firstOptional', () {
+    test('iterable.firstOptional is present', () {
+      expect(<int>[1,2,3].firstOptional.isPresent, isTrue);
+    });
+    test('iterable.firstOptional is empty', () {
+      expect(<int>[].firstOptional.isEmpty, isTrue);
+    });
+  });
+  group('iterable.lastWhereOptional', () {
+    test('iterable.lastWhereOptional is present', () {
+      expect(<int>[1,2,3].lastWhereOptional((v) => v == 3).isPresent, isTrue);
+    });
+    test('iterable.lastWhereOptional is empty', () {
+      expect(<int>[1,2,3].lastWhereOptional((v) => v == 4).isEmpty, isTrue);
+    });
+  });
+  group('iterable.lastWhereIndexedOptional', () {
+    test('iterable.lastWhereIndexedOptional is present', () {
+      expect(<int>[1,2,3].lastWhereIndexedOptional((i, v) => i == 2).isPresent, isTrue);
+    });
+    test('iterable.lastWhereIndexedOptional is empty', () {
+      expect(<int>[1,2,3].lastWhereIndexedOptional((i, v) => i == 4).isEmpty, isTrue);
+    });
+  });
+  group('iterable.lastOptional', () {
+    test('iterable.lastOptional is present', () {
+      expect(<int>[1,2,3].lastOptional.isPresent, isTrue);
+    });
+    test('iterable.lastOptional is empty', () {
+      expect(<int>[].lastOptional.isEmpty, isTrue);
+    });
+  });
+  group('iterable.singleWhereOptional', () {
+    test('iterable.singleWhereOptional is present', () {
+      expect(<int>[1,2,3].singleWhereOptional((v) => v == 2).isPresent, isTrue);
+    });
+    test('iterable.singleWhereOptional is present', () {
+      expect(<int>[1,2,2,3].singleWhereOptional((v) => v == 2).isEmpty, isTrue);
+    });
+    test('iterable.singleWhereOptional is empty', () {
+      expect(<int>[1,2,3].singleWhereOptional((v) => v == 4).isEmpty, isTrue);
+    });
+  });
+  group('iterable.singleWhereIndexedOptional', () {
+    test('iterable.singleWhereIndexedOptional is present', () {
+      expect(<int>[1,2,3].singleWhereIndexedOptional((i, v) => i == 2).isPresent, isTrue);
+    });
+    test('iterable.singleWhereIndexedOptional is present', () {
+      expect(<int>[1,2,3].singleWhereIndexedOptional((i, v) => i == 2 || v == 2).isEmpty, isTrue);
+    });
+    test('iterable.singleWhereIndexedOptional is empty', () {
+      expect(<int>[1,2,3].singleWhereIndexedOptional((i, v) => i == 4).isEmpty, isTrue);
+    });
+  });
+  group('iterable.singleOptional', () {
+    test('iterable.singleOptional is present', () {
+      expect(<int>[1].singleOptional.isPresent, isTrue);
+    });
+    test('iterable.singleOptional is empty', () {
+      expect(<int>[1,2,3].singleOptional.isEmpty, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
Hi Tonio,

This PR contains a port of the null aware Iterable extensions to Optional, see:

https://github.com/dart-lang/collection/blob/master/lib/src/iterable_extensions.dart

I am suggesting inclusion of this extension as the most common place where I have to deal with wrapping null values in my code is to do with searching in collections. The following code is now very common as you can no longer call `.toOptional` on null objects since dart became typesafe.
```
final List<int> data = [1, 2, 3];
final maybeValue = Optional.ofNullable(data.firstWhereOrNull((int i) => i == 3));

becomes

final maybeValue = data.firstWhereOptional((int i) => i == 3);
```