### PR TITLE
Optional.empty when Iterable is empty

### DIFF
--- a/lib/optional.dart
+++ b/lib/optional.dart
@@ -6,5 +6,6 @@ export 'optional_internal.dart'
         Optional,
         OptionalExtension,
         OptionalIterableExtension,
+        OptionalWrappedIterableExtension,
         NoValuePresentError,
         empty;

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -5,6 +5,14 @@ extension OptionalExtension<T extends Object> on T {
   Optional<T> get toOptional => Optional.of(this);
 }
 
+extension OptionalWrappedIterableExtension<S, T extends Iterable<S>> on T {
+  /// Iterable wrapped in Optional, or `Optional.empty()` if the Iterable is empty.
+  Optional<T> get emptyAsOptional {
+    if (isEmpty) return Optional.empty();
+    return Optional.of(this);
+  }
+}
+
 /// Extensions that apply to all iterables.
 extension OptionalIterableExtension<T> on Iterable<T> {
   /// The first element satisfying [test], or `Optional.empty()` if there are none.

--- a/test/src/extension.dart
+++ b/test/src/extension.dart
@@ -9,6 +9,15 @@ void runExtensionTests() {
       expect(1.toOptional, equals(Optional.of(1)));
     });
   });
+  group('iterable.emptyAsOptional', () {
+    test('iterable.emptyAsOptional is present', () {
+      expect(
+          <int>[1, 2, 3].emptyAsOptional.value, [1, 2, 3]);
+    });
+    test('iterable.emptyAsOptional is empty', () {
+      expect(<int>[].emptyAsOptional.isEmpty, isTrue);
+    });
+  });
   group('iterable.firstWhereOptional', () {
     test('iterable.firstWhereOptional is present', () {
       expect(


### PR DESCRIPTION
I have been finding quite often while coding that an empty Iterable has been equating to an empty Optional and that I am repeated repeating the boiler plate code. Could you please consider this for inclusion.